### PR TITLE
docs: Update file tree in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Here is important files and folders listed:
 
 ```
 ├── .checker.yml    <- checker config - how to test, export files etc
-├── .deadlines.yml  <- deadlines config - when to open/close tasks - sent to manytask
+├── .manytask.yml   <- course structure - task groups, tasks, deadlines - sent to manytask
 │
 ├── .docker        <- docker image with testing environment
 ├── .dockerignore  <- dockerignore file - important to minimize image size


### PR DESCRIPTION
After version 1.0 of the checker, the .yml file that describes the structure of the course tasks and their deadlines was renamed from '.deadlines.yml' to '.manytask.yml'. This is now reflected in the docs, where the file tree is described.
